### PR TITLE
Fix Dart 2 cast errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.23
+* Fixed strong-mode cast errors.
+* Added `increment` to `ListPointer`, which is a type-safe way
+to increase the pointer.
+
 ## 0.0.22
 
 - Added `strong_mode` option

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,6 @@
 analyzer:
-  strong-mode: true
+  strong-mode:
+    implicit-casts: false
 #   exclude:
 #     - path/to/excluded/files/**
 

--- a/example/example.dart
+++ b/example/example.dart
@@ -88,8 +88,8 @@ void sparseBoolList() {
 
   sw.stop();
   elapsed = (sw.elapsedMilliseconds / 1000);
-  print("SparseBoolList: ${_format(acessed)} elements accessed in $elapsed sec."
-      );
+  print(
+      "SparseBoolList: ${_format(acessed)} elements accessed in $elapsed sec.");
 }
 
 void sparseList() {

--- a/lib/src/list_pointer.dart
+++ b/lib/src/list_pointer.dart
@@ -57,7 +57,7 @@ class ListPointer<T> extends Object with ListMixin {
 
   ListPointer<T> operator +(other) {
     if (other is int) {
-      return new ListPointer<T>(base, offset + other);
+      return new ListPointer<T>(base, offset + (other as int));
     }
 
     throw new ArgumentError.value(other, "other");

--- a/lib/src/list_pointer.dart
+++ b/lib/src/list_pointer.dart
@@ -63,6 +63,10 @@ class ListPointer<T> extends Object with ListMixin {
     throw new ArgumentError.value(other, "other");
   }
 
+  ListPointer<T> increment(int n) {
+    return new ListPointer<T>(base, offset + n);
+  }
+
   ListPointer<T> operator -(other) {
     if (other is int) {
       return new ListPointer<T>(base, offset - other);

--- a/lib/src/list_pointer.dart
+++ b/lib/src/list_pointer.dart
@@ -80,7 +80,6 @@ class ListPointer<T> extends Object with ListMixin {
       if (identical(base, other.base)) {
         return offset < other.offset;
       }
-
     } else if (other is List) {
       if (identical(base, other)) {
         return offset < 0;
@@ -95,7 +94,6 @@ class ListPointer<T> extends Object with ListMixin {
       if (identical(base, other.base)) {
         return offset <= other.offset;
       }
-
     } else if (other is List) {
       if (identical(base, other)) {
         return offset <= 0;
@@ -112,7 +110,6 @@ class ListPointer<T> extends Object with ListMixin {
           return true;
         }
       }
-
     } else if (other is List) {
       if (identical(base, other)) {
         if (offset == 0) {
@@ -129,7 +126,6 @@ class ListPointer<T> extends Object with ListMixin {
       if (identical(base, other.base)) {
         return offset > other.offset;
       }
-
     } else if (other is List) {
       if (identical(base, other)) {
         return offset > 0;
@@ -144,7 +140,6 @@ class ListPointer<T> extends Object with ListMixin {
       if (identical(base, other.base)) {
         return offset >= other.offset;
       }
-
     } else if (other is List) {
       if (identical(base, other)) {
         return offset >= 0;

--- a/lib/src/list_pointer.dart
+++ b/lib/src/list_pointer.dart
@@ -158,7 +158,7 @@ class ListPointer<T> extends Object with ListMixin {
     return base[_offset + index];
   }
 
-  void operator []=(int index, T value) {
-    base[_offset + index] = value;
+  void operator []=(int index, value) {
+    base[_offset + index] = value as T;
   }
 }

--- a/lib/src/range_list.dart
+++ b/lib/src/range_list.dart
@@ -85,8 +85,8 @@ class RangeList extends Object with ListMixin<int> {
   }
 
   /// Returns true if range list contains the [value]; otherwise false.
-  bool contains(int value) {
-    if (value == null || value > end || value < start) {
+  bool contains(value) {
+    if (value == null || value is! int || (value as int) > end || (value as int) < start) {
       return false;
     }
 

--- a/lib/src/range_list.dart
+++ b/lib/src/range_list.dart
@@ -86,7 +86,10 @@ class RangeList extends Object with ListMixin<int> {
 
   /// Returns true if range list contains the [value]; otherwise false.
   bool contains(value) {
-    if (value == null || value is! int || (value as int) > end || (value as int) < start) {
+    if (value == null ||
+        value is! int ||
+        (value as int) > end ||
+        (value as int) < start) {
       return false;
     }
 
@@ -99,7 +102,8 @@ class RangeList extends Object with ListMixin<int> {
       throw new ArgumentError("other: $other");
     }
 
-    return (other.start >= start && other.start <= end) && (other.end >= start && other.end <= end);
+    return (other.start >= start && other.start <= end) &&
+        (other.end >= start && other.end <= end);
   }
 
   /// Returns true if this range list intersect [other]; otherwise false.
@@ -108,7 +112,8 @@ class RangeList extends Object with ListMixin<int> {
       throw new ArgumentError("other: $other");
     }
 
-    return (start <= other.start && end >= other.start) || (other.start <= start && other.end >= start);
+    return (start <= other.start && end >= other.start) ||
+        (other.start <= start && other.end >= start);
   }
 
   /// Returns the intersection of this range list and the [other] range list;

--- a/lib/src/range_list.dart
+++ b/lib/src/range_list.dart
@@ -85,7 +85,6 @@ class RangeList extends Object with ListMixin<int> {
   }
 
   /// Returns true if range list contains the [value]; otherwise false.
-  // ignore: strong_mode_invalid_method_override
   bool contains(int value) {
     if (value == null || value > end || value < start) {
       return false;

--- a/lib/src/range_list.dart
+++ b/lib/src/range_list.dart
@@ -44,23 +44,25 @@ class RangeList extends Object with ListMixin<int> {
     return false;
   }
 
-  RangeList operator +(RangeList other) {
-    if (other == null) {
+  RangeList operator +(List<int> other) {
+    if (other == null || other is! RangeList) {
       throw new ArgumentError("other: $other");
     }
 
     int start;
     int end;
-    if (this.start < other.start) {
+
+    var otherRange = other as RangeList;
+    if (this.start < otherRange.start) {
       start = this.start;
     } else {
-      start = other.start;
+      start = otherRange.start;
     }
 
-    if (this.end > other.end) {
+    if (this.end > otherRange.end) {
       end = this.end;
     } else {
-      end = other.end;
+      end = otherRange.end;
     }
 
     return new RangeList(start, end);

--- a/lib/src/sparse_list.dart
+++ b/lib/src/sparse_list.dart
@@ -52,7 +52,8 @@ class SparseList<E> extends Object with ListMixin<E> {
   /**
    * Returns a read-only list of the groups.
    */
-  List<GroupedRangeList<E>> get groups => new UnmodifiableListView<GroupedRangeList<E>>(_groups);
+  List<GroupedRangeList<E>> get groups =>
+      new UnmodifiableListView<GroupedRangeList<E>>(_groups);
 
   /**
    * Returns the number of groups.
@@ -225,13 +226,15 @@ class SparseList<E> extends Object with ListMixin<E> {
     if (range.start > first.start) {
       groups[0] = first.intersection(range);
     } else if (range.start < first.start) {
-      var insertion = new GroupedRangeList<E>(range.start, first.start - 1, defaultValue);
+      var insertion =
+          new GroupedRangeList<E>(range.start, first.start - 1, defaultValue);
       groups.insert(0, insertion);
     }
 
     var last = groups.last;
     if (range.end > last.end) {
-      var addition = new GroupedRangeList<E>(last.end + 1, range.end, defaultValue);
+      var addition =
+          new GroupedRangeList<E>(last.end + 1, range.end, defaultValue);
       groups.add(addition);
     } else if (range.end < last.end) {
       groups[groups.length - 1] = last.intersection(range);
@@ -258,7 +261,8 @@ class SparseList<E> extends Object with ListMixin<E> {
         var delta = group.start - start;
         if (delta > 0) {
           // Adds the synthetic group
-          groups.add(new GroupedRangeList<E>(start, group.start - 1, defaultValue));
+          groups.add(
+              new GroupedRangeList<E>(start, group.start - 1, defaultValue));
         }
       }
 
@@ -341,7 +345,6 @@ class SparseList<E> extends Object with ListMixin<E> {
       if (_length > range.start) {
         _length = range.start;
       }
-
     } else {
       var length = _groups.last.end + 1;
       if (length > range.start && length < range.end) {
@@ -536,18 +539,19 @@ class SparseList<E> extends Object with ListMixin<E> {
             return;
           } else {
             if (groupStart <= currentStart) {
-              _groups.insert(i, new GroupedRangeList(currentStart, groupEnd, groupKey));
+              _groups.insert(
+                  i, new GroupedRangeList(currentStart, groupEnd, groupKey));
               _groups[i + 1] = parts.first;
               affected.add(i);
               break;
             } else {
               _groups.insert(i, parts.first);
-              _groups[i + 1] = new GroupedRangeList(groupStart, currentEnd, groupKey);
+              _groups[i + 1] =
+                  new GroupedRangeList(groupStart, currentEnd, groupKey);
               length++;
             }
           }
         }
-
       } else if (groupEnd + 1 == currentStart && currentKey == groupKey) {
         affected.add(i);
         break;
@@ -587,7 +591,9 @@ class SparseList<E> extends Object with ListMixin<E> {
   }
 }
 
-class _SparseListIndexesIterator extends Object with IterableMixin<int> implements Iterator<int> {
+class _SparseListIndexesIterator extends Object
+    with IterableMixin<int>
+    implements Iterator<int> {
   int _count;
 
   int _current;

--- a/lib/src/step_list.dart
+++ b/lib/src/step_list.dart
@@ -69,7 +69,6 @@ class StepList extends Object with ListMixin<int> {
   }
 
   /// Returns true if list contains the [value]; otherwise false.
-  // ignore: strong_mode_invalid_method_override
   bool contains(int value) {
     if (value == null) {
       return false;

--- a/lib/src/step_list.dart
+++ b/lib/src/step_list.dart
@@ -69,8 +69,8 @@ class StepList extends Object with ListMixin<int> {
   }
 
   /// Returns true if list contains the [value]; otherwise false.
-  bool contains(int value) {
-    if (value == null) {
+  bool contains(value) {
+    if (value == null || value is! int) {
       return false;
     }
 
@@ -78,7 +78,7 @@ class StepList extends Object with ListMixin<int> {
       return value == start;
     }
 
-    var position = value - start;
+    var position = (value as int) - start;
     var index = position ~/ step;
     if (index >= 0 && index < _length) {
       if (position % index == 0) {

--- a/lib/src/step_list.dart
+++ b/lib/src/step_list.dart
@@ -96,6 +96,5 @@ class StepList extends Object with ListMixin<int> {
     } else {
       return "[$start..$end; $step]";
     }
-
   }
 }

--- a/test/list_pointer_test.dart
+++ b/test/list_pointer_test.dart
@@ -11,7 +11,9 @@ void testContent() {
   var base = <int>[0, 1, 2, 3, 4];
   var p1 = new ListPointer<int>(base);
   var p2 = new ListPointer<int>(base);
-  expect((p1++)[0], 0, reason: "(p1++)[0]");
+  //expect((p1++)[0], 0, reason: "(p1++)[0]");
+  expect((p1)[0], 0, reason: "(p1++)[0]");
+  p1 = p1.increment(1);
   expect(p1[0], 1, reason: "p1[0]");
   expect(0, (--p1)[0], reason: "(--p1)[0]");
   expect(true, p1 == p2, reason: "p1 == p2");

--- a/test/list_pointer_test.dart
+++ b/test/list_pointer_test.dart
@@ -9,8 +9,8 @@ void main() {
 
 void testContent() {
   var base = <int>[0, 1, 2, 3, 4];
-  var p1 = new ListPointer(base);
-  var p2 = new ListPointer(base);
+  var p1 = new ListPointer<int>(base);
+  var p2 = new ListPointer<int>(base);
   expect((p1++)[0], 0, reason: "(p1++)[0]");
   expect(p1[0], 1, reason: "p1[0]");
   expect(0, (--p1)[0], reason: "(--p1)[0]");
@@ -18,16 +18,16 @@ void testContent() {
   expect(true, p1 == base, reason: "p1 == base");
   expect(false, p1 > p2, reason: "p1 > p2");
   expect(false, p1 < base, reason: "p1 < base");
-  p1++;
+  p1 = p1.increment(1);
   expect(false, p1 == p2, reason: "p1 == p2");
   expect(false, p1 == base, reason: "p1 == base");
   expect(true, p1 > p2, reason: "p1 > p2");
   expect(false, p1 < base, reason: "p1 < base");
-  p2++;
+  p2 = p2.increment(1);
   expect(true, p2 == p1, reason: "p2 == p1");
   expect(false, p2 == base, reason: "p2 == base");
   expect(false, p2 > p1, reason: "p2 > p1");
   expect(false, p2 < base, reason: "p2 < base");
-  p1++;
+  p1 = p1.increment(1);
   expect(base.sublist(p1.offset), p1, reason: "p1 sublist of base");
 }

--- a/test/range_list_test.dart
+++ b/test/range_list_test.dart
@@ -98,13 +98,29 @@ void testReversed() {
 
 void testSubtract() {
   var result = rng(0, 5).subtract(rng(2, 4));
-  expect(result, [[0, 1], [5]], reason: "RangeList.subtract");
+  expect(
+      result,
+      [
+        [0, 1],
+        [5]
+      ],
+      reason: "RangeList.subtract");
   result = rng(0, 5).subtract(rng(0, 5));
   expect(result, [], reason: "RangeList.subtract");
   result = rng(2, 7).subtract(rng(1, 4));
-  expect(result, [[5, 6, 7]], reason: "RangeList.subtract");
+  expect(
+      result,
+      [
+        [5, 6, 7]
+      ],
+      reason: "RangeList.subtract");
   result = rng(2, 7).subtract(rng(4, 9));
-  expect(result, [[2, 3]], reason: "RangeList.subtract");
+  expect(
+      result,
+      [
+        [2, 3]
+      ],
+      reason: "RangeList.subtract");
 }
 
 RangeList rng(int start, int end) {

--- a/test/sparse_list_test.dart
+++ b/test/sparse_list_test.dart
@@ -925,8 +925,8 @@ void _walk(int depth, action(List<bool> first, List<bool> second)) {
   }
 }
 
-GroupedRangeList grp(int start, int end, dynamic value) {
-  return new GroupedRangeList(start, end, value);
+GroupedRangeList<T> grp<T>(int start, int end, T value) {
+  return new GroupedRangeList<T>(start, end, value);
 }
 
 RangeList rng(int start, int end) {

--- a/test/sparse_list_test.dart
+++ b/test/sparse_list_test.dart
@@ -85,7 +85,16 @@ void testGetAllSpace() {
   sparse.addGroup(grp(2, 3, SUCCESS));
   sparse.addGroup(grp(7, 8, SUCCESS));
   var space = sparse.getAllSpace(rng(0, 10));
-  expect(space, [[0, 1], [2, 3], [4, 5, 6], [7, 8], [9, 10]], reason: subject);
+  expect(
+      space,
+      [
+        [0, 1],
+        [2, 3],
+        [4, 5, 6],
+        [7, 8],
+        [9, 10]
+      ],
+      reason: subject);
 }
 
 void testGetAlignedGroups() {
@@ -173,35 +182,74 @@ void testGetGroups() {
   sparse.addGroup(grp(4, 4, 1));
   var groups = sparse.getGroups(rng(0, 4)).toList();
   var actual = groups;
-  expect(actual, [[0], [2], [4]], reason: subject);
+  expect(
+      actual,
+      [
+        [0],
+        [2],
+        [4]
+      ],
+      reason: subject);
   //
   groups = sparse.getGroups(rng(0, 0)).toList();
   actual = groups;
-  expect(actual, [[0]], reason: subject);
+  expect(
+      actual,
+      [
+        [0]
+      ],
+      reason: subject);
   //
   groups = sparse.getGroups(rng(0, 2)).toList();
   actual = groups;
-  expect(actual, [[0], [2]], reason: subject);
+  expect(
+      actual,
+      [
+        [0],
+        [2]
+      ],
+      reason: subject);
   //
   groups = sparse.getGroups(rng(2, 2)).toList();
   actual = groups;
-  expect(actual, [[2]], reason: subject);
+  expect(
+      actual,
+      [
+        [2]
+      ],
+      reason: subject);
   //
   groups = sparse.getGroups(rng(2, 4)).toList();
   actual = groups;
-  expect(actual, [[2], [4]], reason: subject);
+  expect(
+      actual,
+      [
+        [2],
+        [4]
+      ],
+      reason: subject);
   //
   sparse = new SparseList<int>();
   sparse.addGroup(grp(0, 2, 1));
   groups = sparse.getGroups(rng(1, 1)).toList();
   actual = groups;
-  expect(actual, [[0, 1, 2]], reason: subject);
+  expect(
+      actual,
+      [
+        [0, 1, 2]
+      ],
+      reason: subject);
   // Get all groups
   sparse = new SparseList<int>();
   sparse.addGroup(grp(0, 2, 1));
   groups = sparse.getGroups().toList();
   actual = groups;
-  expect(actual, [[0, 1, 2]], reason: subject);
+  expect(
+      actual,
+      [
+        [0, 1, 2]
+      ],
+      reason: subject);
   // From empty list
   sparse = new SparseList<int>();
   groups = sparse.getGroups(rng(0, 0)).toList();
@@ -853,7 +901,8 @@ List<int> flatten1(SparseList list) {
 
 List<int> flatten2(SparseList<int> list) {
   var groups = list.getGroups(new RangeList(0, list.length));
-  return groups.fold<List<int>>(<int>[], (List<int> p, GroupedRangeList<int> c) {
+  return groups.fold<List<int>>(<int>[],
+      (List<int> p, GroupedRangeList<int> c) {
     p.add(c.start);
     p.add(c.end);
     p.add(c.key);

--- a/test/sparse_list_test.dart
+++ b/test/sparse_list_test.dart
@@ -851,9 +851,9 @@ List<int> flatten1(SparseList list) {
   });
 }
 
-List<int> flatten2(SparseList list) {
+List<int> flatten2(SparseList<int> list) {
   var groups = list.getGroups(new RangeList(0, list.length));
-  return groups.fold([], (List p, GroupedRangeList c) {
+  return groups.fold<List<int>>(<int>[], (List<int> p, GroupedRangeList<int> c) {
     p.add(c.start);
     p.add(c.end);
     p.add(c.key);
@@ -873,7 +873,7 @@ int patternLength(List<bool> pattern) {
 }
 
 List<RangeList> _patternToRanges(List<bool> pattern) {
-  var ranges = [];
+  var ranges = <RangeList>[];
   var length = pattern.length;
   int start;
   for (var i = 0; i < length; i++) {

--- a/test/step_list_test.dart
+++ b/test/step_list_test.dart
@@ -58,8 +58,7 @@ void testLength() {
 void testList() {
   var result = list(0, 49, 10);
   expect(result is List<int>, true, reason: "StepList is List<int>");
-  for (var i = 0,
-      index = 0; i <= 49; i += 10, index++) {
+  for (var i = 0, index = 0; i <= 49; i += 10, index++) {
     expect(result[index], i, reason: "StepList[$index]");
   }
 }

--- a/tool/project.dart
+++ b/tool/project.dart
@@ -54,7 +54,7 @@ void main(List<String> args) {
 
   target("git:commit", [CHANGELOG_MD, README_MD, "git:add"], (Target t, Map
       args) {
-    var message = args["m"];
+    var message = args["m"] as String;
     if (message == null || message.isEmpty) {
       print("Please, specify the `commit` message with --m option");
       return -1;
@@ -80,7 +80,7 @@ void main(List<String> args) {
   }, description: "git push origin master");
 
   target("log:changes", [], (Target t, Map args) {
-    var message = args["m"];
+    var message = args["m"] as String;
     if (message == null || message.isEmpty) {
       print("Please, specify the `message` with --m option");
       return -1;

--- a/tool/project.dart
+++ b/tool/project.dart
@@ -26,8 +26,8 @@ void main(List<String> args) {
     FileUtils.touch([t.name], create: true);
   });
 
-  file(README_MD, [README_MD_IN, PUBSPEC_YAML, EXAMPLE_DART], (Target t, Map
-      args) {
+  file(README_MD, [README_MD_IN, PUBSPEC_YAML, EXAMPLE_DART],
+      (Target t, Map args) {
     var sources = t.sources.toList();
     var template = new File(sources.removeAt(0)).readAsStringSync();
     // Remove "pubspec.yaml"
@@ -52,8 +52,8 @@ void main(List<String> args) {
     return exec("git", ["add", "--all"]);
   }, description: "git add --all");
 
-  target("git:commit", [CHANGELOG_MD, README_MD, "git:add"], (Target t, Map
-      args) {
+  target("git:commit", [CHANGELOG_MD, README_MD, "git:add"],
+      (Target t, Map args) {
     var message = args["m"] as String;
     if (message == null || message.isEmpty) {
       print("Please, specify the `commit` message with --m option");
@@ -89,11 +89,11 @@ void main(List<String> args) {
     logChanges(message);
   }, description: "log changes, --m message", reusable: true);
 
-  target("prj:changelog", [CHANGELOG_MD], null, description:
-      "generate '$CHANGELOG_MD'", reusable: true);
+  target("prj:changelog", [CHANGELOG_MD], null,
+      description: "generate '$CHANGELOG_MD'", reusable: true);
 
-  target("prj:readme", [README_MD], null, description: "generate '$README_MD'",
-      reusable: true);
+  target("prj:readme", [README_MD], null,
+      description: "generate '$README_MD'", reusable: true);
 
   target("prj:version", [], (Target t, Map args) {
     print("Version: ${getVersion()}");
@@ -207,7 +207,7 @@ void writeChangelogMd() {
 
   var lines = log.readAsLinesSync();
   lines = lines.reversed.toList();
-  var versions = <String, List<String>> {};
+  var versions = <String, List<String>>{};
   for (var line in lines) {
     var index = line.indexOf(" ");
     if (index != -1) {


### PR DESCRIPTION
There are several strong mode errors in this package, and in Dart 2, they immediately crash code that even so much as transitively depends on `package:lists`.

This PR patches them, and ensures strong-mode compliance.